### PR TITLE
Fix Codeception script for newer versions of PHPUnit

### DIFF
--- a/pre_commit_hooks/php-codecept.sh
+++ b/pre_commit_hooks/php-codecept.sh
@@ -42,7 +42,7 @@ done;
 
 echo "Running command $exec_command ${args}"
 command_result=`eval "$exec_command ${args}"`
-if [[ $command_result =~ FAILURES ]]
+if [[ $command_result =~ FAILURES || $command_result =~ ERRORS! ]]
 then
     echo "Failures detected in unit tests..."
     echo "$command_result"


### PR DESCRIPTION
with newer versions of phpunit the script is not detecting failures

the command seems to pass simply because it is depending on the string FAILURES to appear which is not the case anymore, now the output comes as ERRORS!